### PR TITLE
Fix redirect to / and /docs endpoint for some versions

### DIFF
--- a/landing-pages/site/static/.htaccess
+++ b/landing-pages/site/static/.htaccess
@@ -1,9 +1,11 @@
+RedirectMatch Permanent ^/((1\.10\.[0-9]+|2\.[0-9.]+|stable)/.*)$ "https://airflow.apache.org/docs/apache-airflow/$1"
+RedirectMatch Permanent ^/docs/((1\.10\.[0-9]+|2\.[0-9.]+|stable)/.*)$ "https://airflow.apache.org/docs/apache-airflow/$1"
+
+# Airflow 1.10.x
 RedirectMatch Permanent ^/docs/(stable|1.10.10)/api(\.html)?$ "https://airflow.apache.org/docs/apache-airflow/$1/rest-api-ref"
 RedirectMatch Permanent ^/docs/(stable|1.10.10)/(cli|macros)(\.html)?$ "https://airflow.apache.org/docs/apache-airflow/$1/$2-ref"
 RedirectMatch Permanent ^/((_api|_images|_modules|_sources|_static|howto)/.*)$ "https://airflow.apache.org/docs/apache-airflow/stable/$1"
-RedirectMatch Permanent ^/((1.10.1|1.10.2|1.10.3|1.10.4|1.10.5|1.10.6|1.10.7|1.10.8|1.10.9|1.10.10)/.*)$ "https://airflow.apache.org/docs/apache-airflow/$1"
 RedirectMatch Permanent ^/((api|changelog|cli|concepts|errors|faq|genindex|http-routingtable|installation|integration|kubernetes|license|lineage|macros|metrics|plugins|privacy_notice|profiling|project|py-modindex|scheduler|search|security|start|timezone|tutorial|ui)(\.html)?)$ "https://airflow.apache.org/docs/apache-airflow/stable/$1"
-RedirectMatch Permanent ^/docs/((1.10.1|1.10.2|1.10.3|1.10.4|1.10.5|1.10.6|1.10.7|1.10.8|1.10.9|1.10.10|1.10.11|1.10.12|1.10.13|stable)/.*)$ "https://airflow.apache.org/docs/apache-airflow/$1"
 
 Redirect Permanent /objects.inv https://airflow.apache.org/docs/apache-airflow/stable/objects.inv
 


### PR DESCRIPTION
Some versions like >=1.10.14 and >=2.0.0 don't get correctly redirected to its documentation page.